### PR TITLE
updated interface-filter in MicrosoftWindows.pm

### DIFF
--- a/src/perllib/Torrus/DevDiscover/MicrosoftWindows.pm
+++ b/src/perllib/Torrus/DevDiscover/MicrosoftWindows.pm
@@ -83,9 +83,9 @@ if( not defined( $interfaceFilter ) )
      
      'WAN Miniport Ethernet' => {
          'ifType'  => 6,                        # ethernetCsmacd
-         'ifDescr' => '^WAN\s+Miniport'
+         'ifDescr' => '^WAN[-|\s+]Miniport'
          },
-     
+
      'QoS Packet Scheduler' => {
          'ifType'  => 6,                        # ethernetCsmacd
          'ifDescr' => 'QoS\s+Packet\s+Scheduler'


### PR DESCRIPTION
Apparently depending on Windows version there is 'WAN-Miniport' or 'WAN Miniport'. Fixed the filter to match both versions.
