### PR TITLE
Updates to RFC2863_IF_MIB

### DIFF
--- a/src/perllib/Torrus/DevDiscover/RFC2863_IF_MIB.pm
+++ b/src/perllib/Torrus/DevDiscover/RFC2863_IF_MIB.pm
@@ -143,6 +143,7 @@ sub discover
             {
                 $interface->{'ifSpeed'} = $speed;
                 $interface->{'NormalizedSpeed'} = $speed;
+                $interface->{'ifSpeedMonitoring'} = 1;
             }
         }
     }
@@ -191,6 +192,7 @@ sub discover
                 {
                     $interface->{'NormalizedSpeed'} = $hspeed * 1000000;
                 }
+                $interface->{'ifSpeedMonitoring'} = 1;
             }
         }
 
@@ -1187,6 +1189,10 @@ sub buildConfig
                                               $summary, $intfNode );
                 }
             }
+        } else {
+            Debug('Excluding interface: ' .
+                  $interface->{$data->{'nameref'}{'ifReferenceName'}});
+            delete $data->{'interfaces'}{$ifIndex};
         }
     }
     


### PR DESCRIPTION
a) Discovery of interface speed is inoperable since "ifSpeedMonitoring"
   is never set

b) Difficulties can arise in user-developed discovery modules since
   RFC2863_IF_MIB does not discard an interface when no templates have
   been assigned to the interface
