### PR TITLE
Updates to WRED handling in CiscoIOS_cbQoS

### DIFF
--- a/plugins/cbqos/DevDiscover/CiscoIOS_cbQoS.pm
+++ b/plugins/cbqos/DevDiscover/CiscoIOS_cbQoS.pm
@@ -758,9 +758,12 @@ sub buildChildrenConfigs
         }
         elsif( $objType eq 'randomDetect')
         {
+            my $exponweight = $configRef->{'cbQosREDCfgExponWeight'};
             $subtreeName = 'WRED';
-            $objectName = 'WRED';
+            $objectName = $exponweight;
             $subtreeComment = 'Weighted Random Early Detect Statistics';
+            $objectNick = 'red_'.$exponweight;
+            $param->{'cbqos-red-exponential-weight'} = $exponweight;
             $param->{'legend'} =
                 sprintf('Exponential Weight: %d;',
                         $configRef->{'cbQosREDCfgExponWeight'});


### PR DESCRIPTION
The subtree name and object name for Weighted Random Early Detect objects
are the same, and no nickname is attributed to such an object