### PR TITLE
default parameters automatic linking

### DIFF
--- a/plugins/siam/siam-config.pl
+++ b/plugins/siam/siam-config.pl
@@ -55,6 +55,18 @@ push(@Torrus::SIAMDD::loadModules,
      'ifDescr',
      'ifAlias');
 
+# parameters for automatic linking of SIAM::DeviceComponents
+# to SIAM::ServiceComponents
+
+# activiate automatic linking
+$Torrus::SIAMDD::ifmib_search_svcc_in_description = 0;
+
+# pattern to search for
+$Torrus::SIAMDD::ifmib_search_svcc_pattern = '\{(\d+)\}';
+
+# SIAM::ServiceComponent prefix (if needed)
+$Torrus::SIAMDD::ifmib_search_svcc_prefix = 'SC';
+
 
 require '@siam_siteconfig_pl@';
 


### PR DESCRIPTION
Added parameters for automatic linking of SIAM::DeviceComponents and SIAM::ServiceComponents to the default config template. Feature is deactivated by default.