### PR TITLE
Fix Typos in Manpages found by Debian Lintian

### DIFF
--- a/src/doc/manpages/torrus.pod.in
+++ b/src/doc/manpages/torrus.pod.in
@@ -69,7 +69,7 @@ Accepted commands:
 
 =head1 OPTIONS
 
-Refer to approproate manpages for options for each Torrus command.
+Refer to appropriate manpages for options for each Torrus command.
 
 =head1 SEE ALSO
 

--- a/src/doc/manpages/torrus_configsnapshot.pod.in
+++ b/src/doc/manpages/torrus_configsnapshot.pod.in
@@ -73,7 +73,7 @@ Create a new tree with only the snapshot file in it. Compile the tree.
 
 =item *
 
-At this stage, it is up to the user to decide wether to continue running the
+At this stage, it is up to the user to decide whether to continue running the
 collector and monitor daemons for this new tree. The old data may be preserved
 for historical reference, and collector may be run with the newest tree
 structure and definitions.

--- a/src/doc/manpages/torrus_devdiscover.pod.in
+++ b/src/doc/manpages/torrus_devdiscover.pod.in
@@ -68,7 +68,7 @@ provided that it exists and it is not older than the specified number of days.
 
 =item B<--threads>=I<INTEGER>
 
-If the threads are enabled in the local Perl, this option determins
+If the threads are enabled in the local Perl, this option determines
 how many parallel discovery threads are to be executed.
 The discovery jobs are distributed per output files, thus it makes
 sence to use threads only when there are many output files defined in

--- a/src/doc/manpages/torrus_genddx.pod.in
+++ b/src/doc/manpages/torrus_genddx.pod.in
@@ -40,7 +40,7 @@ hostnames. Hostnames may have the form C<host:devname> where C<devname> is
 a symbolic device name.
 
 This utility is designed to be used only once, in order to generate
-the discovery XML canvas, for futher manual editing. It generates only
+the discovery XML canvas, for further manual editing. It generates only
 basic set of parameters, and there are much more of those that you may
 use to customize the discovery process.
 

--- a/src/doc/manpages/torrus_launcher.pod.in
+++ b/src/doc/manpages/torrus_launcher.pod.in
@@ -47,7 +47,7 @@ Starts all required collectors and monitors
 
 =item * stop
 
-Stops runnig collectors and monitors andn waits for them to finish
+Stops running collectors and monitors andn waits for them to finish
 within certain timeout.
 
 =item * status

--- a/src/doc/manpages/torrus_schedulerinfo.pod.in
+++ b/src/doc/manpages/torrus_schedulerinfo.pod.in
@@ -106,7 +106,7 @@ delaying).
 
 =item Min, Max, Average, Exp Average
 
-The time values are displayed in four columns: Mimimum, Maximum and Average
+The time values are displayed in four columns: Minimum, Maximum and Average
 values since last reset, and Exponential decay value, which may be interpreted
 as the average for last several values. With defaults defined in
 F<torrus-config.pl>, 95% of the average is calculated from last 3 values.
@@ -125,7 +125,7 @@ How much time the too long run took.
 
 =item RRD Queue
 
-In a multithreaded environment, the RRD files are writen in a background
+In a multithreaded environment, the RRD files are written in a background
 thread. This value shows the length of the RRD update queue at the beginning
 of each update cycle.
 


### PR DESCRIPTION
I: torrus-common: spelling-error-in-manpage usr/share/man/man7/torrus_launcher.7.gz runnig running
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus.8.gz approproate appropriate
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus_configsnapshot.8.gz wether whether
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus_devdiscover.8.gz determins determines
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus_genddx.8.gz futher further
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus_schedulerinfo.8.gz Mimimum Minimum
I: torrus-common: spelling-error-in-manpage usr/share/man/man8/torrus_schedulerinfo.8.gz writen written