### PR TITLE
Suppress uptime collection and graphing

### DIFF
--- a/src/doc/snmpdiscovery.pod.in
+++ b/src/doc/snmpdiscovery.pod.in
@@ -719,6 +719,10 @@ if set to C<yes>, disables processing of IF-MIB completely.
 Defines the child subtree name within host-level subtree where system CPU
 and memory statistics are located. Default: C<System_Performance>.
 
+=item * C<RFC2790_HOST_RESOURCES::suppress-uptime>
+
+If set to C<yes>, system uptime will not be collected and graphed.
+
 =item * C<RFC2670_DOCS_IF::upstreams-only>
 
 If set to C<yes>, only the DOCSIS upstream statistics are enabled, and

--- a/src/lib/Torrus/DevDiscover/RFC2790_HOST_RESOURCES.pm
+++ b/src/lib/Torrus/DevDiscover/RFC2790_HOST_RESOURCES.pm
@@ -237,8 +237,13 @@ sub buildConfig
         }
 
         my @templates =
-            ('RFC2790_HOST_RESOURCES::hr-system-performance-subtree',
-             'RFC2790_HOST_RESOURCES::hr-system-uptime');
+            ('RFC2790_HOST_RESOURCES::hr-system-performance-subtree');
+
+        unless( $devdetails->paramEnabled('RFC2790_HOST_RESOURCES::suppress-uptime') )
+        {
+            push( @templates, 'RFC2790_HOST_RESOURCES::hr-system-uptime' );
+        };
+
         if( $devdetails->hasCap('hrSystemNumUsers') )
         {
             push( @templates, 'RFC2790_HOST_RESOURCES::hr-system-num-users' );


### PR DESCRIPTION
Hi again,

small feature request: add an option to turn off the system uptime graph.

I never figured out why it is there, it just looks weird. I'd even recommend to turn it on by default.

A textual representation of the system uptime might be nice eg:
> Location: …
> Contact: …
> Description: …
> **Uptime: 430 days, 13 hours, 3 minutes and 56 seconds**

But collecting the system uptime in a RRD file is also futile IMHO. You'll only ever need the last value - and rollovers ie. reboots.

Cheers,
	Christopher