### PR TITLE
Pull request - Spell check and data-file name uniformization

### DIFF
--- a/src/bin/gc.in
+++ b/src/bin/gc.in
@@ -35,14 +35,14 @@ fi
 @GIT@ gc
 
 if [ $? -ne 0 ]; then
-    echo "git gc retuirned error" 1>&2
+    echo "git gc returned error" 1>&2
     exit 1
 fi
 
 @GIT@ update-server-info
 
 if [ $? -ne 0 ]; then
-    echo "git update-server-info retuirned error" 1>&2
+    echo "git update-server-info returned error" 1>&2
     exit 1
 fi
 

--- a/src/lib/Torrus/DevDiscover/CiscoGeneric.pm
+++ b/src/lib/Torrus/DevDiscover/CiscoGeneric.pm
@@ -341,7 +341,7 @@ sub buildConfig
         my $filePerSensor =
             $devdetails->paramEnabled('CiscoGeneric::file-per-sensor');
         
-        $subtreeParam->{'data-file'} = '%snmp-host%_sensors' .
+        $subtreeParam->{'data-file'} = '%system-id%_sensors' .
             ($filePerSensor ? '_%sensor-index%':'') .
             ($fahrenheit ? '_fahrenheit':'') . '.rrd';
 


### PR DESCRIPTION
Hello Stan,

Here is a pull request for (1) fixing some very minor spell errors, but also for (2) uniformizing the data-file name for the Cisco sensors which currently have a name based on their SNMP host (%snmp-host%), while other data files use the system ID (%system-id%).

I see no side effects with (1). But (2) may introduce some historical data loss when a Torrus admin upgrade from a previous version... I let you decide whether this is worth the change or not.

Best regards,
Yann